### PR TITLE
check if the given argument is an array or object

### DIFF
--- a/Classes/Controller/PartialOutputController.php
+++ b/Classes/Controller/PartialOutputController.php
@@ -58,11 +58,15 @@ class PartialOutputController extends ActionController {
 		if ($this->partialRegistrationUtility->isRegistered($extension, $partial)) {
 			$configuration = $this->partialRegistrationUtility->getConfiguration($extension, $partial);
 			$passingArguments = [];
+
+			if (is_array($configuration) || is_object($configuration))
+			{
 			foreach ($configuration[2] as $allowedArguments) {
 				if (isset($_GET[$allowedArguments])) {
 					$passingArguments[$allowedArguments] = strip_tags(urldecode($_GET[$allowedArguments]));
 				}
 			}
+		}
 
 			return $this->getPartial($extension, $partial, $passingArguments);
 		}


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - In PartialOutputController.php check if the given argument is an array or object to prevent an invalid argument exception
  -
  -
